### PR TITLE
Also look in inst/ for REFERENCES.bib

### DIFF
--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -176,7 +176,10 @@ findBibFile <- function(package) {
     } else {
         attempt <- system.file( "REFERENCES.bib", package = package )
         if( !nzchar(attempt) ){
+          attempt <- system.file( "inst/REFERENCES.bib", package = package )
+          if ( !nzchar(attempt) ){
             stop( sprintf( "no bibtex database for package '%s'", package ) )
+          }
         }
         attempt
     }


### PR DESCRIPTION
This is where packages using [Rdpack](https://cran.r-project.org/web/packages/Rdpack/index.html) will store their REFERENCES file.

