### PR TITLE
Also parse AND-joned list of author names (fix #18)

### DIFF
--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -40,7 +40,7 @@ cleanupLatex <- function (x){
 
 #' @importFrom utils as.personList
 ArrangeAuthors <- function (x){
-  rx <- "[[:space:]]+and[[:space:]]+"
+  rx <- "[[:space:]]+(and|AND)[[:space:]]+"
   x <- gsub('[[:space:]]{2,}', ' ', x, useBytes = TRUE)
   authors <- lapply(strsplit(x, rx)[[1]], ArrangeSingleAuthor)
   as.personList(authors)

--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -40,9 +40,9 @@ cleanupLatex <- function (x){
 
 #' @importFrom utils as.personList
 ArrangeAuthors <- function (x){
-  rx <- "[[:space:]]+(and|AND)[[:space:]]+"
+  rx <- "(?i)[[:space:]]+and[[:space:]]+"
   x <- gsub('[[:space:]]{2,}', ' ', x, useBytes = TRUE)
-  authors <- lapply(strsplit(x, rx)[[1]], ArrangeSingleAuthor)
+  authors <- lapply(strsplit(x, rx, perl = TRUE)[[1]], ArrangeSingleAuthor)
   as.personList(authors)
 }
 


### PR DESCRIPTION
Besides this fix, I have a problem with `author = {LastName1, LastName2, LastName3}`-type of lists. Would adding `|,` into the `()`-group solve this?