### PR TITLE
Fix encoding issue on Windows

### DIFF
--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -254,7 +254,7 @@ read.bib <- function(file = findBibFile(package) ,
         stop( "'read.bib' only supports reading from files, 'file' should be a character vector of length one" )
     }
     srcfile <- switch( encoding,
-                      "unknown" = srcfile( file ),
+                      "unknown" = srcfile( file, encoding = "native.enc" ),
                       srcfile( file, encoding = encoding ) )
 
     out <- withCallingHandlers(tryCatch(.External( "do_read_bib", file = file,
@@ -268,6 +268,10 @@ read.bib <- function(file = findBibFile(package) ,
                              if( any( grepl( "syntax error, unexpected [$]end", w)))
                                invokeRestart("muffleWarning")
                            })
+
+    # Force encoding of parsed output to UTF-8 if necessary. See #20
+    if (encoding == "UTF-8") out <- lapply(out, `Encoding<-`, "UTF-8")
+
     # keys <- lapply(out, function(x) attr(x, 'key'))
     at  <- attributes(out)
     if((typeof(out) != "integer") || (getRversion() < "3.0.0"))

--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -199,7 +199,11 @@ findBibFile <- function(package) {
 #' @param srcfile output of \code{\link{srcfile}}
 #' @export
 do_read_bib <- function(file, encoding = "unknown", srcfile){
-  .External( "do_read_bib", file=file, encoding=encoding, srcfile=srcfile, PACKAGE = "bibtex" )
+  out <- .External( "do_read_bib", file=file, encoding=encoding, srcfile=srcfile, PACKAGE = "bibtex" )
+
+  # Force encoding of parsed output to UTF-8 if necessary. See #20
+  if (encoding == "UTF-8") out <- lapply(out, `Encoding<-`, "UTF-8")
+  out
 }
 
 #' bibtex parser
@@ -254,7 +258,7 @@ read.bib <- function(file = findBibFile(package) ,
         stop( "'read.bib' only supports reading from files, 'file' should be a character vector of length one" )
     }
     srcfile <- switch( encoding,
-                      "unknown" = srcfile( file, encoding = "native.enc" ),
+                      "unknown" = srcfile( file ),
                       srcfile( file, encoding = encoding ) )
 
     out <- withCallingHandlers(tryCatch(.External( "do_read_bib", file = file,

--- a/R/bibtex.R
+++ b/R/bibtex.R
@@ -370,7 +370,7 @@ write.bib <- function(entry, file="Rpackages.bib", append = FALSE, verbose = TRU
     fh <- file(file, open = if(append) "a+" else "w+" )
     on.exit( if( isOpen(fh) ) close(fh) )
     if( verbose ) message("Writing ", length(bibs) , " Bibtex entries ... ", appendLF=FALSE)
-    writeLines(toBibtex(bibs), fh)
+    writeLines(toBibtex(bibs), fh, useBytes = TRUE)
     #writeLines(do.call("c", lapply(bibs, as.character)), fh)
     if(verbose) message("OK\nResults written to file '", file, "'")
 


### PR DESCRIPTION
### Pull request overview

Please see the details in #20. Fixes #20. 

Changes include:

* Re-encode parsed entries to UTF-8 if input `encoding` is `UTF-8` in both `do_read_bib()` and `read.bib()`
* Prevent re-encoding the text in the file() connection when writing bib by setting `useBytes` to `TRUE` in `writeLines()`
